### PR TITLE
Adding `Dalli::RateLimiter.would_exceed?`

### DIFF
--- a/dalli-rate_limiter.gemspec
+++ b/dalli-rate_limiter.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "dalli", "~> 2.7.6"
 
-  spec.add_development_dependency "bundler", "~> 1.11.0"
+  spec.add_development_dependency "bundler", ">= 1.11.0"
   spec.add_development_dependency "connection_pool", "~> 2.2.0"
   #spec.add_development_dependency "kgio", "~> 2.10.0"
   spec.add_development_dependency "rake", "~> 10.5.0"

--- a/spec/dalli/rate_limiter_spec.rb
+++ b/spec/dalli/rate_limiter_spec.rb
@@ -47,4 +47,33 @@ describe Dalli::RateLimiter do
 
     Then { result == 2 }
   end
+
+  context "with would_exceed?" do
+    context "with no previous attempts" do
+      When(:result) { lim.would_exceed? "test_key_7" }
+
+      Then { !result }
+    end
+
+    context "after too many attempts" do
+      When(:result) {
+        5.times { lim.exceeded? "test_key_8" }
+        lim.would_exceed? "test_key_8"
+      }
+
+      Then { result && result > 0 }
+    end
+
+    context "with almost too many requests" do
+      When(:result) { lim.would_exceed? "test_key_9", lim.max_requests }
+
+      Then { !result }
+    end
+
+    context "with too many requests" do
+      When(:result) { lim.would_exceed? "test_key_10", lim.max_requests + 1 }
+
+      Then { result == -1 }
+    end
+  end
 end


### PR DESCRIPTION
This method is an alternative to `Dalli::RateLimiter.exceeded?` for use cases where you need to know whether quota is still available without actually consuming it.